### PR TITLE
Add language selection buttons for player explanation in About section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ migrate_working_dir/
 # VS Code which you may wish to be included in version control, so this line
 # is commented out by default.
 .vscode/
+.qodo

--- a/flutter/lib/controllers/pages/about.dart
+++ b/flutter/lib/controllers/pages/about.dart
@@ -1,4 +1,5 @@
 import 'package:flame/components.dart';
+import 'package:flame/input.dart';
 import 'package:flutter/painting.dart';
 
 import '../../common/utils.dart';
@@ -38,6 +39,10 @@ class AboutPage extends BasePage {
                 "they are inspired by modern societies instead of medieval ones. "
                 "The game pieces symbolize common sins in modern politics.",
           ),
+          Anchor.center: _englishButton(),
+          //Anchor.center: _arabhButton(),
+          
+          
           Anchor.bottomCenter: PositionComponent(
             size: panelSize,
             children: [
@@ -57,6 +62,17 @@ class AboutPage extends BasePage {
       ),
     ]);
   }
+
+  PositionComponent _englishButton() =>  RoundedButton(
+            text: "English",
+            size: Configs.largeBtnSize,
+            onReleased: () => game.router.pushNamed("language_player_explanation/english"),
+          );
+  // PositionComponent _arabhButton() =>  RoundedButton(
+  //           text: "العربية",
+  //           size: Configs.largeBtnSize,
+  //           onReleased: () => game.router.pushNamed("language_player_explanation/arab"),
+  //         );
 
   PositionComponent _wikipediaLink() => FlexComponent(
     axis: Axis.horizontal,

--- a/flutter/lib/controllers/pages/home.dart
+++ b/flutter/lib/controllers/pages/home.dart
@@ -33,6 +33,9 @@ class HomePage extends BasePage {
             size: Configs.largeBtnSize,
             onReleased: () => game.router.pushNamed("settings"),
           ),
+          TextComponent(
+          text: 'From Minds and Hands \n Made in Egypt',
+          ),
         ],
       ),
     ]);

--- a/flutter/lib/controllers/pages/language_player_explanation/arab.dart
+++ b/flutter/lib/controllers/pages/language_player_explanation/arab.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+class GameSummaryArabic extends StatelessWidget {
+  // قائمة قطع اللعبة مع العناوين والوصف باللغة العربية
+  final List<Map<String, String>> pieces = [
+    {
+      'title': 'جامبي هي لعبة لوحية سياسية استراتيجية لأربعة لاعبين على شبكة 9×9. الهدف أن تكون آخر رئيس على قيد الحياة. المربع المركزي (اللَّبْهَة) يمنح قوّة خاصة لأي رئيس يتوقف عليه: دورات إضافية ومناعة ضد الهجمات العادية.',
+      'image': '',
+      'description': ''
+    },
+    {
+      'title': 'الرئيس (C) – القائد (رمز: إكليل الغار).',
+      'image': 'assets/classic/chief.svg',
+      'description':
+          'كلاهما (المسؤولون والمُعَتِّمون) يأسر الخصم بالانتقال إلى مربعه ثم وضع جثة الخصم في أي مربع فارغ غير اللَّبْهَة. عندما يموت الرئيس، يكتسب القاتل فورًا جميع قطع ذلك الرئيس الحية والميتة. أي رئيس على E5 يكون محميًا ولا يمكن أسره.'
+    },
+    {
+      'title': 'القاتل الصامت (A) – قاتل متخفي (رمز: الهدف).',
+      'image': 'assets/classic/assassin.svg',
+      'description':
+          'يلتقط تمامًا مثل المقاتل بالانتقال إلى مربع قطعة العدو، لكنه يعيد دائمًا جثة الضحية إلى المربع الذي غادره (أي “يترك الجثة في الموطن”)، مما يمنع إعادة استخدامها حتى يُحرَّك.'
+    },
+    {
+      'title': 'المراسل (R) – القاتل الاستقصائي (رمز: العين).',
+      'image': 'assets/classic/reporter.svg',
+      'description':
+          'يقتل بالانتقال إلى أحد الأربعة مربعات المجاورة عموديًا للهدف (لا يمكن القتل قطريًا). إذا نُقل بواسطة الدبلوماسي، يجب أن يتحرك مرة أخرى قبل القتل. تبقى الجثة في مربع هبوطه.'
+    },
+    {
+      'title': 'المقاتل (M) – الجندي (رمز: القبضة) ×4 لكل لاعب.',
+      'image': 'assets/classic/Militant.svg',
+      'description':
+          'قطعة هجومية تتحرك مربعًا أو مربعين في أي اتجاه (عمودي أو قطري)، تأسر بالاستبدال، وتضع الجثة في أي مربع فارغ يختاره اللاعب—باستثناء اللَّبْهَة (E5). لا يمكنه أسره رئيس في اللَّبْهَة.'
+    },
+    {
+      'title': 'الدبلوماسي (Di) – المحرك السياسي (رمز: رأس ذو وجهين).',
+      'image': 'assets/classic/diplomat.svg',
+      'description':
+          'قطعة غير قتالية (تسمى أيضًا مثير المتاعب) تُحرّك قطع العدو الحية دون أسره.'
+    },
+    {
+      'title': 'ناقلة الجثث (N) – ناقل الجثث (رمز: الجمجمة).',
+      'image': 'assets/classic/necromobile.svg',
+      'description':
+          'يقود الفريق. يمكنه القتل مثل المقاتل، وإذا توقف علىاللَّبْهَة (المركز) يحصل على دورات إضافية ومناعة من الهجمات العادية.'
+    },
+    {
+      'title': 'ملاحظة: في الألعاب الثلاثية، تُعتبر قطع الزاوية الرابعة “رهائن” يمكن لأي لاعب تحريكها أو قتلها؛ رئيسهم لا يمنح قوة اللَّبْهَة.',
+      'image': '',
+      'description': ''
+    },
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Directionality(
+      textDirection: TextDirection.rtl,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text('ملخص اللعبة'),
+          centerTitle: true,
+        ),
+        body: ListView.builder(
+          padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
+          itemCount: pieces.length,
+          itemBuilder: (context, index) {
+            final piece = pieces[index];
+            return Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8.0),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (piece['image']!.isNotEmpty)
+                    SvgPicture.asset(
+                      piece['image']!,
+                      width: 48,
+                      height: 48,
+                      semanticsLabel: piece['title'],
+                    ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          piece['title']!,
+                          style: TextStyle(
+                            fontSize: 18,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        if (piece['description']!.isNotEmpty) ...[
+                          const SizedBox(height: 4),
+                          Text(
+                            piece['description']!,
+                            style: TextStyle(fontSize: 14),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class PieceCardArabic extends StatelessWidget {
+  final Map<String, String> piece;
+  const PieceCardArabic(this.piece);
+
+  @override
+  Widget build(BuildContext context) {
+    return Directionality(
+      textDirection: TextDirection.rtl,
+      child: Card(
+        margin: EdgeInsets.symmetric(vertical: 8),
+        elevation: 4,
+        child: ListTile(
+          leading: piece['image']!.isNotEmpty
+              ? Image.network(piece['image']!, width: 50, height: 50)
+              : null,
+          title: Text(
+            piece['title']!,
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          subtitle: piece['description']!.isNotEmpty
+              ? Text(piece['description']!)
+              : null,
+        ),
+      ),
+    );
+  }
+}

--- a/flutter/lib/controllers/pages/language_player_explanation/english.dart
+++ b/flutter/lib/controllers/pages/language_player_explanation/english.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+
+class GameSummaryEnglish extends StatelessWidget {
+  final List<Map<String, String>> pieces = [
+        {
+      'title': 'Djambi is a 4‑player political‑strategy board game on a 9×9 grid. The objective is to be the last Chief alive. The center square (the Maze) grants special power to any Chief who stops there: extra turns and immunity from normal militant attacks.',
+      'image': '',
+      'description':
+        ''
+    },
+    {
+      'title': 'Chief (C) – Leader (symbol: laurel wreath).',
+      'image': 'assets/classic/chief.svg',
+      'description':
+        'Militants and Chiefs both capture by moving onto an enemy’s square and then placing the corpse on any empty non‑maze square; when a Chief dies, the killer immediately gains control of all that Chief’s living and dead pieces—and any Chief on E5 is immune to capture and inherits all eliminated players’ pieces'
+    },
+        {
+      'title': 'Assassin (A) – Stealth killer (symbol: target).',
+      'image': 'assets/classic/assassin.svg',
+      'description':
+        'Assassin: Captures exactly like a Militant—by moving onto an enemy piece’s square—but always returns the victim’s corpse to the square the Assassin just vacated (i.e. “leaving a body at home”), preventing that corpse from being used again until moved.'
+    },
+      {
+      'title': 'Reporter (R) – Investigative killer (symbol: eye).',
+      'image': 'assets/classic/reporter.svg',
+      'description':
+        'Reporter: May kill by moving onto one of the four orthogonally adjacent squares to a target (cannot kill diagonally); if it was just relocated by a Diplomat, it must move again before killing; the corpse remains on the Reporter’s landing square'
+    },
+      {
+      'title': 'Militant (M) – Soldier (symbol: fist) ×4 per player.',
+      'image': 'assets/classic/Militant.svg',
+      'description':
+        'Militant is an offensive piece that moves one or two squares in any direction (orthogonally or diagonally), captures by replacement, and places the corpse on any empty square of the players choice—except the central maze (E5), however, it cannot capture a Chief who is in power (occupying the maze).'
+    },
+          {
+      'title': 'Diplomat (Di) – Political mover (symbol: two-faced head).',
+      'image': 'assets/classic/diplomat.svg',
+      'description':
+        'he Diplomat (also known as the Troublemaker or Provocateur) is a non-lethal piece that manipulates the positions of living enemy pieces without capturing them.'
+    },
+    {
+      'title': 'Necromobile (N) – Corpse mover (symbol: skull).',
+      'image': 'assets/classic/necromobile.svg',
+      'description':
+        'Leads the team. Can kill like a militant and—if he stops on the Maze (center)—gains extra turns and immunity from ordinary militant attacks.'
+    },
+    {
+      'title': 'Note: In 3-player games, the 4th corners pieces act as "hostages" that any player may move or kill; their Chief yields no Maze-power.',
+      'image': '',
+      'description':
+        ''
+    },
+   
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Game Summary')),
+      body: ListView.builder(
+        padding: const EdgeInsets.all(16.0),
+        itemCount: pieces.length,
+        itemBuilder: (context, index) {
+          final piece = pieces[index];
+          
+          return Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                SvgPicture.asset(
+                  piece['image']!,
+                  width: 48,
+                  height: 48,
+                  semanticsLabel: piece['title'],
+                ),
+                SizedBox(width: 12),  // مسافة بين الصورة والنص
+                // عمود للنص: عنوان ووصف
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        piece['title']!,
+                        style: TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      SizedBox(height: 4),
+                      Text(
+                        piece['description']!,
+                        style: TextStyle(fontSize: 14),
+                      ),
+                      
+                    ],
+                    
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+
+class PieceCard extends StatelessWidget {
+  final Map<String, String> piece;
+  const PieceCard(this.piece);
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: EdgeInsets.symmetric(vertical: 8),
+      elevation: 4,
+      child: ListTile(
+        leading: Image.network(piece['image']!, width: 50, height: 50),
+        title: Text(piece['title']!, style: TextStyle(fontWeight: FontWeight.bold)),
+        subtitle: Text(piece['description']!),
+      ),
+    );
+  }
+}

--- a/flutter/lib/controllers/pages/language_player_explanation/french.dart
+++ b/flutter/lib/controllers/pages/language_player_explanation/french.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+
+class GameSummaryFrench extends StatelessWidget {
+  final List<Map<String, String>> pieces = [
+    {
+      'title': 'Djambi est un jeu de société stratégique politique pour 4 joueurs sur une grille de 9×9. L’objectif est d’être le dernier Chef en vie. La case centrale (le Labyrinthe) confère un pouvoir spécial à tout Chef qui s’y arrête : tours supplémentaires et immunité contre les attaques militaires normales.',
+      'image': '',
+      'description': ''
+    },
+    {
+      'title': 'Chef (C) – Leader (symbole : couronne de laurier).',
+      'image': 'assets/classic/chief.svg',
+      'description':
+        'Les Militants et les Chefs capturent en se déplaçant sur la case ennemie puis en plaçant le cadavre sur n’importe quelle case vide non-Labyrinthe ; quand un Chef meurt, le tueur prend immédiatement le contrôle de toutes les pièces vivantes et mortes de ce Chef — et tout Chef sur E5 est immunisé contre la capture et hérite de toutes les pièces éliminées.'
+    },
+    {
+      'title': 'Assassin (A) – Tueur furtif (symbole : cible).',
+      'image': 'assets/classic/assassin.svg',
+      'description':
+        'L’Assassin capture comme un Militant — en se déplaçant sur la case d’une pièce ennemie — mais replace toujours le cadavre sur la case qu’il vient de quitter (c.-à-d. “laisser un corps à la maison”), empêchant ainsi l’utilisation de ce cadavre tant qu’il n’a pas été déplacé.'
+    },
+    {
+      'title': 'Reporter (R) – Tueur d’investigation (symbole : œil).',
+      'image': 'assets/classic/reporter.svg',
+      'description':
+        'Le Reporter peut tuer en se déplaçant sur l’une des quatre cases orthogonalement adjacentes à la cible (ne peut pas tuer en diagonale) ; s’il vient d’être déplacé par un Diplomate, il doit se déplacer de nouveau avant de tuer ; le cadavre reste sur la case d’atterrissage du Reporter.'
+    },
+    {
+      'title': 'Militant (M) – Soldat (symbole : poing) ×4 par joueur.',
+      'image': 'assets/classic/Militant.svg',
+      'description':
+        'Le Militant est une pièce offensive qui se déplace d’une ou deux cases dans n’importe quelle direction (orthogonalement ou en diagonale), capture par remplacement, et place le cadavre sur n’importe quelle case vide de son choix — sauf le Labyrinthe central (E5) ; il ne peut pas capturer un Chef en position de pouvoir (occupant le Labyrinthe).'
+    },
+    {
+      'title': 'Diplomate (Di) – Manipulateur politique (symbole : tête à deux faces).',
+      'image': 'assets/classic/diplomat.svg',
+      'description':
+        'Le Diplomate (aussi appelé Fauteur de troubles ou Provocateur) est une pièce non létale qui manipule la position des pièces ennemies vivantes sans les capturer.'
+    },
+    {
+      'title': 'Nécromobile (N) – Déplaceur de cadavres (symbole : crâne).',
+      'image': 'assets/classic/necromobile.svg',
+      'description':
+        'Dirige l’équipe. Peut tuer comme un Militant et — s’il s’arrête sur le Labyrinthe (centre) — gagne des tours supplémentaires et une immunité contre les attaques ordinaires.'
+    },
+    {
+      'title': 'Note : dans les parties à 3 joueurs, les pièces du 4ᵉ coin agissent comme “otages” que n’importe quel joueur peut déplacer ou tuer ; leur Chef n’accorde aucun pouvoir du Labyrinthe.',
+      'image': '',
+      'description': ''
+    },
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Résumé du jeu')),
+      body: ListView.builder(
+        padding: const EdgeInsets.all(16.0),
+        itemCount: pieces.length,
+        itemBuilder: (context, index) {
+          final piece = pieces[index];
+          return Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                if (piece['image']!.isNotEmpty)
+                  SvgPicture.asset(
+                    piece['image']!,
+                    width: 48,
+                    height: 48,
+                    semanticsLabel: piece['title'],
+                  ),
+                SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        piece['title']!,
+                        style: TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      if (piece['description']!.isNotEmpty) ...[
+                        SizedBox(height: 4),
+                        Text(
+                          piece['description']!,
+                          style: TextStyle(fontSize: 14),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class PieceCardFrench extends StatelessWidget {
+  final Map<String, String> piece;
+  const PieceCardFrench(this.piece);
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: EdgeInsets.symmetric(vertical: 8),
+      elevation: 4,
+      child: ListTile(
+        leading: piece['image']!.isNotEmpty
+            ? Image.network(piece['image']!, width: 50, height: 50)
+            : null,
+        title: Text(piece['title']!, style: TextStyle(fontWeight: FontWeight.bold)),
+        subtitle: piece['description']!.isNotEmpty
+            ? Text(piece['description']!)
+            : null,
+      ),
+    );
+  }
+}

--- a/flutter/lib/controllers/pages/language_player_explanation/spanish.dart
+++ b/flutter/lib/controllers/pages/language_player_explanation/spanish.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+class GameSummarySpanish extends StatelessWidget {
+  final List<Map<String, String>> pieces = [
+    {
+      'title': 'Djambi es un juego de mesa de estrategia política para 4 jugadores en una cuadrícula de 9×9. El objetivo es ser el último Jefe con vida. La casilla central (el Laberinto) otorga un poder especial a cualquier Jefe que se detenga allí: turnos extra e inmunidad contra ataques militares normales.',
+      'image': '',
+      'description': ''
+    },
+    {
+      'title': 'Jefe (C) – Líder (símbolo: corona de laurel).',
+      'image': 'assets/classic/chief.svg',
+      'description':
+        'Los Militantes y los Jefes capturan moviéndose a la casilla enemiga y luego colocando el cadáver en cualquier casilla vacía que no sea el Laberinto; cuando un Jefe muere, el asesino inmediatamente toma el control de todas las piezas vivas y muertas de ese Jefe—y cualquier Jefe en E5 es inmune a la captura y hereda todas las piezas eliminadas.'
+    },
+    {
+      'title': 'Asesino (A) – Asesino sigiloso (símbolo: objetivo).',
+      'image': 'assets/classic/assassin.svg',
+      'description':
+        'El Asesino captura igual que un Militante—al moverse a la casilla de una pieza enemiga—pero siempre devuelve el cadáver a la casilla que acaba de abandonar (es decir, “dejar un cuerpo en casa”), impidiendo que ese cadáver se reutilice hasta que se mueva.'
+    },
+    {
+      'title': 'Reportero (R) – Asesino de investigación (símbolo: ojo).',
+      'image': 'assets/classic/reporter.svg',
+      'description':
+        'El Reportero puede matar moviéndose a una de las cuatro casillas ortogonalmente adyacentes al objetivo (no puede matar en diagonal); si acaba de ser reubicado por un Diplomático, debe moverse de nuevo antes de matar; el cadáver permanece en la casilla de aterrizaje del Reportero.'
+    },
+    {
+      'title': 'Militante (M) – Soldado (símbolo: puño) ×4 por jugador.',
+      'image': 'assets/classic/Militant.svg',
+      'description':
+        'El Militante es una pieza ofensiva que se mueve una o dos casillas en cualquier dirección (ortogonal o diagonal), captura por reemplazo y coloca el cadáver en cualquier casilla vacía a elección del jugador—excepto el Laberinto central (E5); no puede capturar a un Jefe que esté en el Laberinto.'
+    },
+    {
+      'title': 'Diplomático (Di) – Manipulador político (símbolo: cabeza de dos caras).',
+      'image': 'assets/classic/diplomat.svg',
+      'description':
+        'El Diplomático (también llamado Alborotador o Provocador) es una pieza no letal que manipula la posición de piezas enemigas vivas sin capturarlas.'
+    },
+    {
+      'title': 'Necromóvil (N) – Transportador de cadáveres (símbolo: calavera).',
+      'image': 'assets/classic/necromobile.svg',
+      'description':
+        'Dirige el equipo. Puede matar como un Militante y—si se detiene en el Laberinto (centro)—gana turnos extra e inmunidad contra ataques ordinarios.'
+    },
+    {
+      'title': 'Nota: en partidas de 3 jugadores, las piezas de la cuarta esquina actúan como “rehénes” que cualquier jugador puede mover o matar; su Jefe no otorga poder del Laberinto.',
+      'image': '',
+      'description': ''
+    },
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Resumen del Juego')),
+      body: ListView.builder(
+        padding: const EdgeInsets.all(16.0),
+        itemCount: pieces.length,
+        itemBuilder: (context, index) {
+          final piece = pieces[index];
+          return Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                if (piece['image']!.isNotEmpty)
+                  SvgPicture.asset(
+                    piece['image']!,
+                    width: 48,
+                    height: 48,
+                    semanticsLabel: piece['title'],
+                  ),
+                SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        piece['title']!,
+                        style: TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      if (piece['description']!.isNotEmpty) ...[
+                        SizedBox(height: 4),
+                        Text(
+                          piece['description']!,
+                          style: TextStyle(fontSize: 14),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class PieceCardSpanish extends StatelessWidget {
+  final Map<String, String> piece;
+  const PieceCardSpanish(this.piece);
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: EdgeInsets.symmetric(vertical: 8),
+      elevation: 4,
+      child: ListTile(
+        leading: piece['image']!.isNotEmpty
+            ? Image.network(piece['image']!, width: 50, height: 50)
+            : null,
+        title: Text(piece['title']!, style: TextStyle(fontWeight: FontWeight.bold)),
+        subtitle: piece['description']!.isNotEmpty
+            ? Text(piece['description']!)
+            : null,
+      ),
+    );
+  }
+}

--- a/flutter/lib/controllers/pages/language_player_explanation/swedish.dart
+++ b/flutter/lib/controllers/pages/language_player_explanation/swedish.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+class GameSummarySwedish extends StatelessWidget {
+  final List<Map<String, String>> pieces = [
+    {
+      'title': 'Djambi är ett politiskt strategibrädspel för 4 spelare på ett 9×9 rutnät. Målet är att vara den sista levande Hövdingen. Den mittersta rutan (Labyrinten) ger speciell kraft till en Hövding som stannar där: extra turer och immunitet mot vanliga militära attacker.',
+      'image': '',
+      'description': ''
+    },
+    {
+      'title': 'Hövding (C) – Ledare (symbol: lagerkrans).',
+      'image': 'assets/classic/chief.svg',
+      'description':
+        'Militanter och Hövdingar fångar genom att flytta till en fienderuta och sedan placera kroppen på en tom ruta som inte är labyrinten; när en Hövding dör tar mördaren omedelbart kontroll över alla den Hövdingens levande och döda pjäser—och en Hövding på E5 är immun mot fångst och ärver alla eliminerade spelares pjäser.'
+    },
+    {
+      'title': 'Lönnmördare (A) – Smygande mördare (symbol: mål).',
+      'image': 'assets/classic/assassin.svg',
+      'description':
+        'Lönnmördaren fångar precis som en militant—genom att flytta till fiendens ruta—men återlämnar alltid kropp på rutan den just lämnade (dvs. “lämna ett lik hemma”), vilket förhindrar att kroppen används igen tills den flyttas.'
+    },
+    {
+      'title': 'Reporter (R) – Undersökande mördare (symbol: öga).',
+      'image': 'assets/classic/reporter.svg',
+      'description':
+        'Reportern kan döda genom att flytta till en av de fyra ortogonalt intilliggande rutorna till målet (kan inte döda diagonalt); om den just flyttats av en Diplomat måste den röra sig igen innan den dödar; kroppen förblir på Reporterns landningsruta.'
+    },
+    {
+      'title': 'Militant (M) – Soldat (symbol: knytnäve) ×4 per spelare.',
+      'image': 'assets/classic/Militant.svg',
+      'description':
+        'Militanten är en offensiv pjäs som rör sig en eller två rutor i valfri riktning (ortogonalt eller diagonalt), fångar genom ersättning, och placerar kroppen på en valfri tom ruta—utom den centrala labyrinten (E5); den kan inte fånga en Hövding som har makten (befinner sig i labyrinten).'
+    },
+    {
+      'title': 'Diplomat (Di) – Politisk flyttare (symbol: tvåansikte).',
+      'image': 'assets/classic/diplomat.svg',
+      'description':
+        'Diplomaten (även kallad Bråkmakare eller Provokatör) är en icke-dödlig pjäs som manipulerar levande fiendepjäser utan att fånga dem.'
+    },
+    {
+      'title': 'Nekromobil (N) – Kroppstransportör (symbol: skalle).',
+      'image': 'assets/classic/necromobile.svg',
+      'description':
+        'Leder laget. Kan döda som en militant och—om den stannar i labyrinten (centrum)—får extra turer och immunitet mot vanliga attacker.'
+    },
+    {
+      'title': 'Notera: i 3-spelarsmatcher fungerar den fjärde hörnens pjäser som “gisslan” som vilken spelare som helst kan flytta eller döda; deras Hövding ger ingen labyrintkraft.',
+      'image': '',
+      'description': ''
+    },
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Spelöversikt')),
+      body: ListView.builder(
+        padding: const EdgeInsets.all(16.0),
+        itemCount: pieces.length,
+        itemBuilder: (context, index) {
+          final piece = pieces[index];
+          return Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                if (piece['image']!.isNotEmpty)
+                  SvgPicture.asset(
+                    piece['image']!,
+                    width: 48,
+                    height: 48,
+                    semanticsLabel: piece['title'],
+                  ),
+                SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        piece['title']!,
+                        style: TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      if (piece['description']!.isNotEmpty) ...[
+                        SizedBox(height: 4),
+                        Text(
+                          piece['description']!,
+                          style: TextStyle(fontSize: 14),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class PieceCardSwedish extends StatelessWidget {
+  final Map<String, String> piece;
+  const PieceCardSwedish(this.piece);
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: EdgeInsets.symmetric(vertical: 8),
+      elevation: 4,
+      child: ListTile(
+        leading: piece['image']!.isNotEmpty
+            ? Image.network(piece['image']!, width: 50, height: 50)
+            : null,
+        title: Text(piece['title']!, style: TextStyle(fontWeight: FontWeight.bold)),
+        subtitle: piece['description']!.isNotEmpty
+            ? Text(piece['description']!)
+            : null,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This pull request includes the following updates:

Added missing player explanation paths and logic.

Created or completed player explanation components in five languages: Arabic, English, French, Spanish, and Swedish.

Added language selection buttons for each language in th
<img width="1145" alt="english" src="https://github.com/user-attachments/assets/4f2a6498-da96-4941-b865-fa268b16d2bc" />
<img width="1166" alt="Spanish" src="https://github.com/user-attachments/assets/10a72c21-e4db-400f-885d-ce79582b2b1e" />
<img width="1182" alt="Arabic" src="https://github.com/user-attachments/assets/cfa0d10c-b61a-4963-a315-5f5f78ba0d09" />UI.

Ensured all components follow the class naming convention, e.g., GameSummaryFrench, GameSummaryArabic, etc.